### PR TITLE
Improve variable name and simplify conditional

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -1055,6 +1055,9 @@ async def check_need_initialize(cur_version: str) -> bool:
         bool: True if Langflow needs to be initialized, False otherwise.
     """
     settings_service = get_settings_service()
-    if not settings_service.settings.init_once_per_version:
-        return True
-    return not await check_if_initialized(cur_version)
+    # Always initialize if init_once_per_version is disabled
+    if settings_service.settings.init_once_per_version:
+        # Only initialize if the current version hasn't been initialized yet
+        return not await check_if_initialized(cur_version)
+    # Otherwise, always initialize
+    return True

--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -1055,6 +1055,6 @@ async def check_need_initialize(cur_version: str) -> bool:
         bool: True if Langflow needs to be initialized, False otherwise.
     """
     settings_service = get_settings_service()
-    if not settings_service.settings.initialize_once_every_version:
+    if not settings_service.settings.init_once_per_version:
         return True
     return not await check_if_initialized(cur_version)

--- a/src/backend/base/langflow/services/settings/base.py
+++ b/src/backend/base/langflow/services/settings/base.py
@@ -242,8 +242,10 @@ class Settings(BaseSettings):
     """If set to True, Langflow will only partially load components at startup and fully load them on demand.
     This significantly reduces startup time but may cause a slight delay when a component is first used."""
 
-    initialize_once_every_version: bool = False
-    """If set to True, Langflow will only initialize the service once in the same version"""
+    init_once_per_version: bool = False
+    """If set to True, Langflow will only initialize once per version.
+    This means that initialization tasks like creating starter projects will only happen when a new version is detected,
+    improving startup time for subsequent runs of the same version."""
 
     @field_validator("dev")
     @classmethod

--- a/src/backend/tests/unit/components/data/test_api_request_component.py
+++ b/src/backend/tests/unit/components/data/test_api_request_component.py
@@ -8,7 +8,7 @@ import pytest
 import respx
 from httpx import Response
 from langflow.components.data import APIRequestComponent
-from langflow.schema import Data, DataFrame, Message
+from langflow.schema import Data, DataFrame
 
 from tests.base import ComponentTestBaseWithoutClient
 
@@ -145,7 +145,6 @@ class TestAPIRequestComponent(ComponentTestBaseWithoutClient):
 
         assert isinstance(result, Data)
         assert result.data["source"] == url
-
 
     @respx.mock
     async def test_make_request_timeout(self, component):


### PR DESCRIPTION
This pull request includes changes to the initialization logic, settings configuration, and test imports in the Langflow backend. The most important changes include renaming a configuration setting, updating the initialization check logic, and cleaning up imports in the test files.

Changes to initialization logic and settings:

* [`src/backend/base/langflow/initial_setup/setup.py`](diffhunk://#diff-0732ac6af4ea09ea32ecf13f818de57171ae1090103d20b2cb18c67df425e631L1058-R1063): Modified the `check_need_initialize` function to always initialize if `init_once_per_version` is disabled and only initialize if the current version hasn't been initialized yet when `init_once_per_version` is enabled.
* [`src/backend/base/langflow/services/settings/base.py`](diffhunk://#diff-c1d45d91203864dca90286f0f322de7fd8f9dd9acadb9c6e0fbb21cc7bf75fc3L245-R248): Renamed the `initialize_once_every_version` setting to `init_once_per_version` and updated its description to clarify its purpose.
