### PR TITLE
fix: handle missing config directory in version initialization

### DIFF
--- a/src/backend/base/langflow/initial_setup/setup.py
+++ b/src/backend/base/langflow/initial_setup/setup.py
@@ -1021,6 +1021,8 @@ async def get_initialized_version() -> str:
         str: The initialized version of Langflow.
     """
     settings_service = get_settings_service()
+    if not settings_service.settings.config_dir:
+        return "0.0.0"
     path = Path(settings_service.settings.config_dir).joinpath("initialized_version")
     return read_version_from_file(path)
 
@@ -1034,6 +1036,8 @@ async def set_initialized_version(cur_version: str | None = None) -> None:
     if not cur_version:
         return
     settings_service = get_settings_service()
+    if not settings_service.settings.config_dir:
+        return
     path = Path(settings_service.settings.config_dir).joinpath("initialized_version")
     write_version_to_file(path, cur_version)
 


### PR DESCRIPTION
This pull request includes changes to handle cases where the `config_dir` is not set in the `settings_service` within the `setup.py` file. The changes ensure that the functions return early if the `config_dir` is not configured, preventing potential errors.

Key changes:

* [`src/backend/base/langflow/initial_setup/setup.py`](diffhunk://#diff-0732ac6af4ea09ea32ecf13f818de57171ae1090103d20b2cb18c67df425e631R1024-R1025): Added a check to return "0.0.0" if `config_dir` is not set in `get_initialized_version` function.
* [`src/backend/base/langflow/initial_setup/setup.py`](diffhunk://#diff-0732ac6af4ea09ea32ecf13f818de57171ae1090103d20b2cb18c67df425e631R1039-R1040): Added a check to return early if `config_dir` is not set in `set_initialized_version` function.